### PR TITLE
ユーザー登録における正規表現設定

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,14 @@
 class User < ApplicationRecord
+
+  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])\w/.freeze
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
           :recoverable, :rememberable, :validatable
-          
-  validates :name, presence: true
+
+          with_options presence: true do
+              validates :password, format: { with: VALID_PASSWORD_REGEX }
+              validates :name, length: { maximum: 10 }
+          end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,29 @@
-<h2>Sign up</h2>
+<h2>新規登録</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+    <%= f.text_field :name, autofocus: true, placeholder:"10文字以内", autocomplete: "name" %>
   </div>
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, placeholder:"PC・携帯どちらでも可", autocomplete: "email" %>
   </div>
 
   <div class="field">
     <%= f.label :password %>
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <em>(<%= @minimum_password_length %>文字より多く設定してください)</em>
     <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.password_field :password, placeholder:"小文字英数字混合でご入力ください", autocomplete: "new-password" %>
   </div>
 
   <div class="field">
     <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, placeholder:"確認用", autocomplete: "new-password" %>
   </div>
 
   <div class="actions">
@@ -31,4 +31,3 @@
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>新規登録</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+<%= form_with(model: @user, url: user_registration_path, method: :post, class: 'registration-main', local: true) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Log in</h2>
+<h2>ログイン</h2>
 
 <%= form_with(model: @user, url: user_session_path ,method: :post, class: 'registration-main', local: true) do |f| %>
 


### PR DESCRIPTION
ユーザー登録における規制を設けたのでご確認ください。

1. ユーザー名を10文字以内での入力が必須
2.パスワードは小文字英数字混合でなければ登録できない
3.新規登録、ログインページのフロント変更

よろしくお願いいたします。